### PR TITLE
reverting to projectkey

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -6,7 +6,7 @@ interface Context {
 }
 
 export interface Props {
-  project: string;
+  projectKey: string;
 }
 
 const FormspreeContext = React.createContext<Context>({
@@ -16,12 +16,12 @@ const FormspreeContext = React.createContext<Context>({
 FormspreeContext.displayName = 'Formspree';
 
 export const FormspreeProvider: React.FC<Props> = props => {
-  if (!props.project) {
-    throw new Error('project is required');
+  if (!props.projectKey) {
+    throw new Error('projectKey is required');
   }
 
   const [client] = useState(() => {
-    return createClient({ project: props.project });
+    return createClient({ projectKey: props.projectKey });
   });
 
   useEffect(() => {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -24,30 +24,32 @@ afterEach(() => {
 it('instantiates a client and provides it via useFormspree hook', () => {
   createClient.mockImplementation(config => ({
     startBrowserSession: () => {},
-    key: config.project
+    key: config.projectKey
   }));
 
   const Component = () => {
     const client = useFormspree();
-    return <div id="client">project: {client.key}</div>;
+    return <div id="client">projectKey: {client.key}</div>;
   };
 
-  const Page = ({ project }) => {
+  const Page = ({ projectKey }) => {
     return (
-      <FormspreeProvider project={project}>
+      <FormspreeProvider projectKey={projectKey}>
         <Component />
       </FormspreeProvider>
     );
   };
 
   act(() => {
-    ReactDOM.render(<Page project="xxx" />, container);
+    ReactDOM.render(<Page projectKey="xxx" />, container);
   });
 
-  expect(container.querySelector('#client').textContent).toBe('project: xxx');
+  expect(container.querySelector('#client').textContent).toBe(
+    'projectKey: xxx'
+  );
 });
 
-it('throws an error if project prop is not provided', () => {
+it('throws an error if projectKey prop is not provided', () => {
   // Mock error console to suppress noise in output
   console.error = jest.fn();
 
@@ -61,5 +63,5 @@ it('throws an error if project prop is not provided', () => {
   });
 
   const error = container.querySelector('#error');
-  expect(error.textContent).toBe('project is required');
+  expect(error.textContent).toBe('projectKey is required');
 });

--- a/test/useForm.test.js
+++ b/test/useForm.test.js
@@ -73,7 +73,7 @@ it('fails it initialize without identifying properties', () => {
 
   act(() => {
     ReactDOM.render(
-      <FormspreeProvider project="xxx">
+      <FormspreeProvider projectKey="xxx">
         <ErrorBoundary>
           <TestForm />
         </ErrorBoundary>
@@ -130,7 +130,7 @@ it('submits a client name', async () => {
 
   act(() => {
     ReactDOM.render(
-      <FormspreeProvider project="xxx">
+      <FormspreeProvider projectKey="xxx">
         <TestForm form="newsletter" />
       </FormspreeProvider>,
       container
@@ -177,7 +177,7 @@ it('submits successfully form key', async () => {
 
   act(() => {
     ReactDOM.render(
-      <FormspreeProvider project="xxx">
+      <FormspreeProvider projectKey="xxx">
         <TestForm form="newsletter" />
       </FormspreeProvider>,
       container
@@ -209,7 +209,7 @@ it('appends extra data to form data', async () => {
 
   act(() => {
     ReactDOM.render(
-      <FormspreeProvider project="xxx">
+      <FormspreeProvider projectKey="xxx">
         <TestForm form="newsletter" extraData={{ extra: 'yep' }} />
       </FormspreeProvider>,
       container
@@ -235,7 +235,7 @@ it('evaluates functions passed in data', async () => {
 
   act(() => {
     ReactDOM.render(
-      <FormspreeProvider project="xxx">
+      <FormspreeProvider projectKey="xxx">
         <TestForm
           form="newsletter"
           extraData={{
@@ -258,7 +258,7 @@ it('evaluates functions passed in data', async () => {
 
 it('reacts to server-side validation errors', async () => {
   mockedCreateClient.mockImplementation(() => ({
-    project: 'xxx',
+    projectKey: 'xxx',
     startBrowserSession: () => {},
     submitForm: (_form, _data, _opts) => {
       return new Promise(resolve => {
@@ -281,7 +281,7 @@ it('reacts to server-side validation errors', async () => {
 
   act(() => {
     ReactDOM.render(
-      <FormspreeProvider project="xxx">
+      <FormspreeProvider projectKey="xxx">
         <TestForm form="newsletter" />
       </FormspreeProvider>,
       container
@@ -302,7 +302,7 @@ it('reacts to server-side validation errors', async () => {
 
 it('reacts to form disabled errors', async () => {
   mockedCreateClient.mockImplementation(() => ({
-    project: 'xxx',
+    projectKey: 'xxx',
     startBrowserSession: () => {},
     submitForm: (_form, _data, _opts) => {
       return new Promise(resolve => {
@@ -324,7 +324,7 @@ it('reacts to form disabled errors', async () => {
 
   act(() => {
     ReactDOM.render(
-      <FormspreeProvider project="xxx">
+      <FormspreeProvider projectKey="xxx">
         <TestForm form="newsletter" />
       </FormspreeProvider>,
       container


### PR DESCRIPTION
The reason I changed to project id was because that's clearly something you can put in your code. Project Key feels like it should be a secret.

I think project key could be OK if the API is clear to put the projectKey in your code. But if the argument is "project", people may still question if putting their project key there is appropriate.