### PR TITLE
add FieldErrorCode type to enhance ErrorPayload type safely

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,11 @@
+type FieldErrorCode =
+  | 'REQUIRED_FIELD_MISSING'
+  | 'REQUIRED_FIELD_EMPTY'
+  | 'TYPE_EMAIL'
+  | 'TYPE_NUMERIC'
+  | 'TYPE_TEXT';
 export interface ErrorPayload {
   field?: string;
-  code: string | null;
+  code: FieldErrorCode | null;
   message: string;
 }


### PR DESCRIPTION
I want to make the `errors` object type safe by defining the field error code as string literal union type.
I got the field error code from the following documents.
https://help.formspree.io/hc/en-us/articles/360055613373-The-Formspree-React-library#errorcodes