### PR TITLE
improve FormspreeProvider type to support React 18

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -15,7 +15,9 @@ const FormspreeContext = React.createContext<Context>({
 
 FormspreeContext.displayName = 'Formspree';
 
-export const FormspreeProvider: React.FC<Props> = props => {
+export const FormspreeProvider: React.FC<
+  React.PropsWithChildren<Props>
+> = props => {
   if (!props.project) {
     throw new Error('project is required');
   }


### PR DESCRIPTION
Starting with React 18, `children` were removed from `React.FC` type.
Therefore, using `FormspreeProvider` in React 18 will result in a type error.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210