### PR TITLE
Making formspree-react (and core) compatible with new version of recaptcha v3

### DIFF
--- a/.changeset/bright-geckos-notice.md
+++ b/.changeset/bright-geckos-notice.md
@@ -1,0 +1,6 @@
+---
+"@formspree/core": patch
+"@formspree/react": patch
+---
+
+Better error handling

--- a/.changeset/bright-geckos-notice.md
+++ b/.changeset/bright-geckos-notice.md
@@ -1,6 +1,0 @@
----
-"@formspree/core": patch
-"@formspree/react": patch
----
-
-Better error handling

--- a/examples/cra-demo/package.json
+++ b/examples/cra-demo/package.json
@@ -14,7 +14,6 @@
     "dev": "react-scripts start",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
     "eject": "react-scripts eject",
     "clean": "rm -rf build && rm -rf node_modules"
   },

--- a/examples/cra-demo/src/App.tsx
+++ b/examples/cra-demo/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
-import { FormspreeProvider } from '@formspree/react';
-import PaymentForm from './PaymentForm';
-import SimpleForm from './SimpleForm';
+import { useState } from "react";
+import { FormspreeProvider } from "@formspree/react";
+import PaymentForm from "./PaymentForm";
+import SimpleForm from "./SimpleForm";
+import RecaptchaForm from "./RecaptchaForm";
 
 const App = () => {
-  const [isStripe, setStripe] = useState(false);
+  const [tab, setTab] = useState("simple");
 
   return (
     <>
@@ -12,32 +13,41 @@ const App = () => {
         <div className="tabs">
           <button
             type="button"
-            className={`tab ${!isStripe && 'active'}`}
-            onClick={() => setStripe(false)}
+            className={`tab ${tab === "simple" && "active"}`}
+            onClick={() => setTab("simple")}
           >
             Simple form
           </button>
           <button
             type="button"
-            className={`tab ${isStripe && 'active'}`}
-            onClick={() => setStripe(true)}
+            className={`tab ${tab === "recaptcha" && "active"}`}
+            onClick={() => setTab("recaptcha")}
+          >
+            ReCaptcha form
+          </button>
+          <button
+            type="button"
+            className={`tab ${tab === "stripe" && "active"}`}
+            onClick={() => setTab("stripe")}
           >
             Stripe form
           </button>
         </div>
-        {isStripe ? (
+        {tab === "stripe" ? (
           <FormspreeProvider
             stripePK={process.env.REACT_APP_STRIPE_PUBLISHABLE_KEY}
           >
             <PaymentForm />
           </FormspreeProvider>
+        ) : tab === "recaptcha" ? (
+          <RecaptchaForm />
         ) : (
           <SimpleForm />
         )}
       </div>
       <footer className="container">
         <p>
-          Powered by:{' '}
+          Powered by:{" "}
           <a href="https://formspree.io?utm_source=formspree-react-demo">
             Formspree
           </a>

--- a/examples/cra-demo/src/PaymentForm.tsx
+++ b/examples/cra-demo/src/PaymentForm.tsx
@@ -31,72 +31,59 @@ const PaymentForm = () => {
     process.env.REACT_APP_PAYMENT_FORM_ID as string
   );
 
-  return (
-    <div
-      style={{
-        maxWidth: 960,
-        margin: "0 auto",
-        fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
-        padding: "4rem 0",
-      }}
-    >
-      {state && state.succeeded ? (
-        <h2>Payment has been handled successfully!</h2>
-      ) : (
-        <form onSubmit={handleSubmit}>
-          <div className="block">
-            <label htmlFor="email">Email</label>
-            <input id="email" type="email" name="email" />
-            <ValidationError
-              field="email"
-              prefix="Email"
-              className="error"
-              errors={state.errors}
-            />
-          </div>
-          <div className="block">
-            <label htmlFor="email">Card details</label>
-            <CardElement options={options} />
-            <ValidationError
-              className="error"
-              field="paymentMethod"
-              errors={state.errors}
-            />
-          </div>
-          <button type="submit" disabled={state.submitting}>
-            {state.submitting ? "Handling payment..." : "Pay"}
-          </button>
+  return state && state.succeeded ? (
+    <h2>Payment has been handled successfully!</h2>
+  ) : (
+    <form onSubmit={handleSubmit}>
+      <div className="block">
+        <label htmlFor="email">Email</label>
+        <input id="email" type="email" name="email" required />
+        <ValidationError
+          field="email"
+          prefix="Email"
+          className="error"
+          errors={state.errors}
+        />
+      </div>
+      <div className="block">
+        <label htmlFor="email">Card details</label>
+        <CardElement options={options} />
+        <ValidationError
+          className="error"
+          field="paymentMethod"
+          errors={state.errors}
+        />
+      </div>
+      <button type="submit" disabled={state.submitting}>
+        {state.submitting ? "Handling payment..." : "Pay"}
+      </button>
 
-          <div className="block info">
-            <p>You can use the following cards for testing:</p>
-            <ul>
-              <CardExample
-                title="Successful charge: 4242 4242 4242 4242"
-                cardNumber="4242424242424242"
-              />
-              <CardExample
-                title="Declined payment: 4000 0000 0000 0002"
-                cardNumber="4000000000000002"
-              />
-              <CardExample
-                title="3D secure: 4000 0027 6000 3184"
-                cardNumber="4000002760003184"
-              />
-            </ul>
-            <span>
-              Use any 3 digits for CVC and any future date for the date
-            </span>
-            <a
-              href="https://stripe.com/docs/testing"
-              target="_blank"
-              rel="noreferrer"
-            >
-              See more on Stripe
-            </a>
-          </div>
-        </form>
-      )}
-    </div>
+      <div className="block info">
+        <p>You can use the following cards for testing:</p>
+        <ul>
+          <CardExample
+            title="Successful charge: 4242 4242 4242 4242"
+            cardNumber="4242424242424242"
+          />
+          <CardExample
+            title="Declined payment: 4000 0000 0000 0002"
+            cardNumber="4000000000000002"
+          />
+          <CardExample
+            title="3D secure: 4000 0027 6000 3184"
+            cardNumber="4000002760003184"
+          />
+        </ul>
+        <span>Use any 3 digits for CVC and any future date for the date</span>
+        <a
+          href="https://stripe.com/docs/testing"
+          target="_blank"
+          rel="noreferrer"
+        >
+          See more on Stripe
+        </a>
+      </div>
+    </form>
   );
 };
 

--- a/examples/cra-demo/src/PaymentForm.tsx
+++ b/examples/cra-demo/src/PaymentForm.tsx
@@ -1,21 +1,21 @@
-import { useMemo } from 'react';
-import { useForm, CardElement, ValidationError } from '@formspree/react';
-import CardExample from './CardExample';
+import { useMemo } from "react";
+import { useForm, CardElement, ValidationError } from "@formspree/react";
+import CardExample from "./CardExample";
 
 const useOptions = () => {
   const options = useMemo(
     () => ({
       style: {
         base: {
-          color: '#424770',
-          letterSpacing: '0.025em',
-          fontFamily: 'Source Code Pro, monospace',
-          '::placeholder': {
-            color: '#aab7c4',
+          color: "#424770",
+          letterSpacing: "0.025em",
+          fontFamily: "Source Code Pro, monospace",
+          "::placeholder": {
+            color: "#aab7c4",
           },
         },
         invalid: {
-          color: '#9e2146',
+          color: "#9e2146",
         },
       },
     }),
@@ -35,9 +35,9 @@ const PaymentForm = () => {
     <div
       style={{
         maxWidth: 960,
-        margin: '0 auto',
-        fontFamily: 'Helvetica Neue, Helvetica, Arial, sans-serif',
-        padding: '4rem 0',
+        margin: "0 auto",
+        fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+        padding: "4rem 0",
       }}
     >
       {state && state.succeeded ? (
@@ -47,6 +47,12 @@ const PaymentForm = () => {
           <div className="block">
             <label htmlFor="email">Email</label>
             <input id="email" type="email" name="email" />
+            <ValidationError
+              field="email"
+              prefix="Email"
+              className="error"
+              errors={state.errors}
+            />
           </div>
           <div className="block">
             <label htmlFor="email">Card details</label>
@@ -58,7 +64,7 @@ const PaymentForm = () => {
             />
           </div>
           <button type="submit" disabled={state.submitting}>
-            {state.submitting ? 'Handling payment...' : 'Pay'}
+            {state.submitting ? "Handling payment..." : "Pay"}
           </button>
 
           <div className="block info">

--- a/examples/cra-demo/src/PaymentForm.tsx
+++ b/examples/cra-demo/src/PaymentForm.tsx
@@ -37,7 +37,7 @@ const PaymentForm = () => {
     <form onSubmit={handleSubmit}>
       <div className="block">
         <label htmlFor="email">Email</label>
-        <input id="email" type="email" name="email" required />
+        <input id="email" type="email" name="email" />
         <ValidationError
           field="email"
           prefix="Email"
@@ -53,6 +53,9 @@ const PaymentForm = () => {
           field="paymentMethod"
           errors={state.errors}
         />
+      </div>
+      <div className="block">
+        <ValidationError className="error" errors={state.errors} />
       </div>
       <button type="submit" disabled={state.submitting}>
         {state.submitting ? "Handling payment..." : "Pay"}

--- a/examples/cra-demo/src/RecaptchaForm.tsx
+++ b/examples/cra-demo/src/RecaptchaForm.tsx
@@ -1,8 +1,23 @@
 import { useForm, ValidationError } from "@formspree/react";
+import { useState } from "react";
 
-const SimpleForm = () => {
+import {
+  GoogleReCaptchaProvider,
+  useGoogleReCaptcha,
+} from "react-google-recaptcha-v3";
+
+const ReCaptchaForm = () => {
+  const { executeRecaptcha } = useGoogleReCaptcha();
+  const [failReCaptcha, setFailReCaptcha] = useState(false);
   const [state, handleSubmit] = useForm(
-    process.env.REACT_APP_SIMPLE_FORM_ID as string
+    process.env.REACT_APP_RECAPTCHA_FORM_ID as string,
+    {
+      data: {
+        "g-recaptcha-response": failReCaptcha
+          ? () => new Promise<string>((resolve) => resolve("Nonsense!"))
+          : executeRecaptcha,
+      },
+    }
   );
 
   return (
@@ -26,8 +41,16 @@ const SimpleForm = () => {
             <input id="name" type="name" name="name" />
           </div>
           <div className="block">
-            <label htmlFor="message">Message</label>
-            <textarea id="message" name="message" rows={10} />
+            <label className="forCheckbox" htmlFor="failRecaptcha">
+              Fail Recaptcha
+            </label>
+            <input
+              id="failReCaptcha"
+              type="checkbox"
+              onChange={(ev) => {
+                setFailReCaptcha(ev.target.checked);
+              }}
+            />
           </div>
           <div className="block">
             <ValidationError className="error" errors={state.errors} />
@@ -41,4 +64,10 @@ const SimpleForm = () => {
   );
 };
 
-export default SimpleForm;
+export default () => (
+  <GoogleReCaptchaProvider
+    reCaptchaKey={process.env.REACT_APP_RECAPTCHA_KEY as string}
+  >
+    <ReCaptchaForm />
+  </GoogleReCaptchaProvider>
+);

--- a/examples/cra-demo/src/index.css
+++ b/examples/cra-demo/src/index.css
@@ -30,6 +30,7 @@ body {
   background-color: #fafafa;
   color: #6772e5;
   transition: 0.5s all ease;
+  margin-right: 1rem;
 }
 
 .tabs .tab:hover {
@@ -43,8 +44,8 @@ body {
   color: #fff;
 }
 
-.tabs .tab:first-of-type {
-  margin-right: 1rem;
+.tabs .tab:last-of-type {
+  margin-right: 0;
 }
 
 label {
@@ -52,6 +53,13 @@ label {
   font-weight: 300;
   letter-spacing: 0.025em;
   display: block;
+}
+
+label.forCheckbox {
+  display: inline-block;
+  margin-bottom: 1em;
+  margin-right: 0.25em;
+  cursor: pointer;
 }
 
 button {
@@ -85,7 +93,7 @@ button:hover {
 }
 
 textarea,
-input,
+input:not([type="checkbox"]),
 .StripeElement {
   display: block;
   margin: 10px 0 20px 0;
@@ -100,6 +108,10 @@ input,
   outline: 0;
   border-radius: 4px;
   background: white;
+}
+
+input[type="checkbox"] {
+  cursor: pointer
 }
 
 input::placeholder {
@@ -137,6 +149,8 @@ input:focus,
 .error {
   color: #e12626;
   display: block;
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 .info {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "eslint-config-acme": "*",
     "prettier": "^2.5.1",
     "turbo": "latest"
+  },
+  "dependencies": {
+    "react-google-recaptcha-v3": "^1.10.0"
   }
 }

--- a/packages/formspree-core/.babelrc
+++ b/packages/formspree-core/.babelrc
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "test": {
+      "presets": [
+        "@babel/preset-env",
+        "@babel/preset-typescript"
+      ]
+    }
+  }
+}

--- a/packages/formspree-core/CHANGELOG.md
+++ b/packages/formspree-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.8.1
+
+### Patch Changes
+
+- Catch Formspree errors using legacy format
+
 ## 2.8.0
 
 ### Minor Changes

--- a/packages/formspree-core/CHANGELOG.md
+++ b/packages/formspree-core/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Changelog
 
-## 2.8.2
-
-### Patch Changes
-
-- 8e233bf: Better error handling
-
 ## 2.8.1
 
 ### Patch Changes
 
 - Catch Formspree errors using legacy format
+- Better error handling
 
 ## 2.8.0
 

--- a/packages/formspree-core/CHANGELOG.md
+++ b/packages/formspree-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.8.2
+
+### Patch Changes
+
+- 8e233bf: Better error handling
+
 ## 2.8.1
 
 ### Patch Changes

--- a/packages/formspree-core/package.json
+++ b/packages/formspree-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formspree/core",
-  "version": "2.8.2",
+  "version": "2.8.1",
   "description": "The core library for Formspree",
   "private": false,
   "homepage": "https://formspree.io",

--- a/packages/formspree-core/package.json
+++ b/packages/formspree-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formspree/core",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "The core library for Formspree",
   "private": false,
   "homepage": "https://formspree.io",

--- a/packages/formspree-core/package.json
+++ b/packages/formspree-core/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --minify",
     "clean": "rm -rf dist && rm -rf node_modules",
-    "dev": "tsup src/index.ts --format esm,cjs --watch --dts --minify",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --sourcemap",
     "lint": "eslint src/*.ts*",
     "test": "jest"
   },

--- a/packages/formspree-core/package.json
+++ b/packages/formspree-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formspree/core",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "The core library for Formspree",
   "private": false,
   "homepage": "https://formspree.io",

--- a/packages/formspree-core/src/core.ts
+++ b/packages/formspree-core/src/core.ts
@@ -1,5 +1,6 @@
 import { Stripe } from '@stripe/stripe-js';
 import {
+  hasErrors,
   SubmissionData,
   SubmissionOptions,
   SubmissionBody,
@@ -53,8 +54,7 @@ export class Client {
     opts: SubmissionOptions = {}
   ): Promise<SubmissionResponse> {
     let endpoint = opts.endpoint || 'https://formspree.io';
-    let fetchImpl =
-      opts.fetchImpl || fetch;
+    let fetchImpl = opts.fetchImpl || fetch;
     let url = this.project
       ? `${endpoint}/p/${this.project}/f/${formKey}`
       : `${endpoint}/f/${formKey}`;
@@ -142,6 +142,9 @@ export class Client {
       return fetchImpl(url, request).then(response => {
         return response.json().then(
           (body: SubmissionBody): SubmissionResponse => {
+            if (!hasErrors(body) && (body as any)?.error) {
+              body = { errors: [{ message: (body as any).error }] };
+            }
             return { body, response };
           }
         );

--- a/packages/formspree-core/src/utils.ts
+++ b/packages/formspree-core/src/utils.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { btoa } from './base64';
 import { version } from '../package.json';
-import { SubmissionResponse } from './forms';
+import { hasErrors, SubmissionResponse } from './forms';
 import { PaymentMethod, Stripe } from '@stripe/stripe-js';
 
 /**
@@ -170,3 +170,13 @@ export const handleSCA = async ({
     };
   }
 };
+
+export function handleLegacyErrorPayload({
+  body,
+  response
+}: SubmissionResponse): SubmissionResponse {
+  if (!hasErrors(body) && (body as any)?.error) {
+    body = { errors: [{ message: (body as any).error }] };
+  }
+  return { body, response };
+}

--- a/packages/formspree-react/.babelrc
+++ b/packages/formspree-react/.babelrc
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "test": {
+      "presets": [
+        "@babel/preset-env",
+        "@babel/preset-typescript",
+        "@babel/preset-react"
+      ],
+      "plugins": ["@babel/plugin-transform-runtime"]
+    }
+  }
+}

--- a/packages/formspree-react/CHANGELOG.md
+++ b/packages/formspree-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.1
+
+### Patch Changes
+
+- Fixed promise detection in extradata
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/formspree-react/CHANGELOG.md
+++ b/packages/formspree-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.2
+
+### Patch Changes
+
+- 8e233bf: Better error handling
+
 ## 2.4.1
 
 ### Patch Changes

--- a/packages/formspree-react/CHANGELOG.md
+++ b/packages/formspree-react/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Changelog
 
-## 2.4.2
-
-### Patch Changes
-
-- 8e233bf: Better error handling
-
 ## 2.4.1
 
 ### Patch Changes
 
 - Fixed promise detection in extradata
+- Better error handling
 
 ## 2.4.0
 

--- a/packages/formspree-react/package.json
+++ b/packages/formspree-react/package.json
@@ -25,7 +25,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external react --minify",
-    "dev": "tsup src/index.ts --format esm,cjs --watch --dts --external react --minify",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --external react --sourcemap",
     "clean": "rm -rf dist && rm -rf node_modules",
     "lint": "eslint src/*.ts*",
     "test": "jest"

--- a/packages/formspree-react/package.json
+++ b/packages/formspree-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formspree/react",
-  "version": "2.4.2",
+  "version": "2.4.1",
   "description": "The React component library for Formspree",
   "private": false,
   "bugs": {

--- a/packages/formspree-react/package.json
+++ b/packages/formspree-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formspree/react",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "The React component library for Formspree",
   "private": false,
   "bugs": {

--- a/packages/formspree-react/package.json
+++ b/packages/formspree-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formspree/react",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "The React component library for Formspree",
   "private": false,
   "bugs": {

--- a/packages/formspree-react/src/types.ts
+++ b/packages/formspree-react/src/types.ts
@@ -11,6 +11,7 @@ export type FieldError = Forms.FieldError;
  * Functions can return undefined to skip this ExtraData value.
  */
 export type ExtraDataValue =
+  | undefined
   | string
   | (() => string)
   | (() => Promise<string>)

--- a/packages/formspree-react/src/useForm.ts
+++ b/packages/formspree-react/src/useForm.ts
@@ -104,19 +104,20 @@ const useForm = (
     // Append extra data from config
     if (typeof extraData === 'object') {
       for (const prop in extraData) {
+        let extraDataValue;
         if (typeof extraData[prop] === 'function') {
-          let extraDataValue = (extraData[prop] as Exclude<
+          extraDataValue = (extraData[prop] as Exclude<
             ExtraDataValue,
             string
           >).call(null);
           if (typeof extraDataValue?.then === 'function') {
             extraDataValue = await extraDataValue;
           }
-          if (extraDataValue !== undefined) {
-            appendExtraData(prop, extraDataValue);
-          }
         } else {
-          appendExtraData(prop, extraData[prop] as string);
+          extraDataValue = extraData[prop];
+        }
+        if (extraDataValue !== undefined) {
+          appendExtraData(prop, extraDataValue as string);
         }
       }
     }

--- a/packages/formspree-react/src/useForm.ts
+++ b/packages/formspree-react/src/useForm.ts
@@ -9,7 +9,7 @@ import {
   SubmissionResponse,
   SubmissionData,
   ErrorBody,
-  FormError,
+  FormError
 } from '@formspree/core';
 
 type FormEvent = React.FormEvent<HTMLFormElement>;
@@ -78,7 +78,7 @@ const useForm = (
     setErrors([]);
   };
 
-  const handleSubmit: SubmitHandler = async (submissionData) => {
+  const handleSubmit: SubmitHandler = async submissionData => {
     const getFormData = async (event: FormEvent) => {
       event.preventDefault();
 
@@ -105,10 +105,11 @@ const useForm = (
     if (typeof extraData === 'object') {
       for (const prop in extraData) {
         if (typeof extraData[prop] === 'function') {
-          let extraDataValue = (
-            extraData[prop] as Exclude<ExtraDataValue, string>
-          ).call(null);
-          if (extraDataValue instanceof Promise) {
+          let extraDataValue = (extraData[prop] as Exclude<
+            ExtraDataValue,
+            string
+          >).call(null);
+          if (typeof extraDataValue?.then === 'function') {
             extraDataValue = await extraDataValue;
           }
           if (extraDataValue !== undefined) {
@@ -123,23 +124,23 @@ const useForm = (
     const createPaymentMethod = async () => {
       const address = {
         ...(formData.address_line1 && {
-          line1: formData.address_line1,
+          line1: formData.address_line1
         }),
         ...(formData.address_line2 && {
-          line2: formData.address_line2,
+          line2: formData.address_line2
         }),
         ...(formData.address_city && {
-          city: formData.address_city,
+          city: formData.address_city
         }),
         ...(formData.address_country && {
-          country: formData.address_country,
+          country: formData.address_country
         }),
         ...(formData.address_state && {
-          state: formData.address_state,
+          state: formData.address_state
         }),
         ...(formData.address_postal_code && {
-          postal_code: formData.address_postal_code,
-        }),
+          postal_code: formData.address_postal_code
+        })
       };
 
       const payload = await stripe.createPaymentMethod({
@@ -150,9 +151,9 @@ const useForm = (
           ...(formData.email && { email: formData.email }),
           ...(formData.phone && { phone: formData.phone }),
           ...(address && {
-            address,
-          }),
-        },
+            address
+          })
+        }
       });
 
       return payload;
@@ -167,7 +168,7 @@ const useForm = (
         createPaymentMethod:
           formspreeContext.client && formspreeContext.client.stripePromise
             ? createPaymentMethod
-            : undefined,
+            : undefined
       })
       .then((result: SubmissionResponse) => {
         let status = result.response.status;

--- a/packages/formspree-react/src/useForm.ts
+++ b/packages/formspree-react/src/useForm.ts
@@ -180,17 +180,17 @@ const useForm = (
           setSucceeded(true);
           setResult(result);
           setErrors([]);
-        } else if (status >= 400 && status < 500) {
+        } else if (status >= 400) {
           body = result.body as ErrorBody;
-
-          if (body.errors) setErrors(body.errors);
-          if (debug) console.log('Validation error', result);
-          setSucceeded(false);
-        } else {
-          if (debug) console.log('Unexpected error', result);
+          if (body.errors) {
+            setErrors(body.errors);
+            if (debug) console.log('Error', result);
+          } else {
+            setErrors([{ message: 'Unexpected error' }]);
+            if (debug) console.log('Unexpected error', result);
+          }
           setSucceeded(false);
         }
-
         return result;
       })
       .catch((error: Error) => {

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
       "outputs": []
     },
     "dev": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^dev"],
       "cache": false
     },
     "clean": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6599,6 +6599,13 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hoopy@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
@@ -10963,12 +10970,19 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
+react-google-recaptcha-v3@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.10.0.tgz#1ec46825fe9b857d7f4ef08ee89fea05e629a9f9"
+  integrity sha512-JBoqU107X8klQmS8tQSbQh1IMsT1fH3kVoArIqnia0rtn0rPNG9Ld+9rD/dHJMculIczSZpGvIJTXXwtsolMcg==
+  dependencies:
+    hoist-non-react-statics "^3.3.2"
+
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-is@^16.13.1, react-is@^16.8.4:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
* improved extradata by detecting thenables, not just Promise instances (needed for compatibility with latest react-google-recaptcha-v3
* added a recaptcha example form
* made formspree-core and -react compatible with our old-school error format like {"error": message}. (which is used for recaptcha errors)
* needed to add back in .babelrc files to run tests with Turborepo
* dropped test script in cra-demo because not compatible with Turborepo (and we didn't have tests)
* some prettier formatting fixes