### PR TITLE
Update README files across all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ A monorepo containing libraries for seamless form integration with [Formspree](h
 Core submission client and types.
 
 ```sh
+npm install @formspree/core
+# or
 yarn add @formspree/core
+# or
+pnpm add @formspree/core
 ```
 
 ### [`@formspree/react`](./packages/formspree-react)
@@ -17,7 +21,11 @@ yarn add @formspree/core
 React hooks and components for Formspree. Supports React 16.8, 17, 18, and 19.
 
 ```sh
+npm install @formspree/react
+# or
 yarn add @formspree/react
+# or
+pnpm add @formspree/react
 ```
 
 ### [`@formspree/ajax`](./packages/formspree-ajax)
@@ -25,7 +33,11 @@ yarn add @formspree/react
 Vanilla JavaScript library for declarative form handling. No framework required.
 
 ```sh
+npm install @formspree/ajax
+# or
 yarn add @formspree/ajax
+# or
+pnpm add @formspree/ajax
 ```
 
 _`@formspree/core` is included as a dependency of both `@formspree/react` and `@formspree/ajax`, so you don't need to install it separately._

--- a/README.md
+++ b/README.md
@@ -4,66 +4,40 @@ A monorepo containing libraries for seamless form integration with [Formspree](h
 
 ## Packages
 
-### `@formspree/core`
+### [`@formspree/core`](./packages/formspree-core)
 
-Core submission client and types. Provides `createClient`, `getDefaultClient`, `SubmissionError`, and submission types.
+Core submission client and types.
 
 ```sh
-npm install @formspree/core
-
 yarn add @formspree/core
-
-pnpm add @formspree/core
 ```
 
-### `@formspree/react`
+### [`@formspree/react`](./packages/formspree-react)
 
-React hooks (`useForm`, `useSubmit`) and components (`ValidationError`) built on top of core.
-
-**Prerequisites:** React 16.8 or higher.
+React hooks and components for Formspree. Supports React 16.8, 17, 18, and 19.
 
 ```sh
-npm install @formspree/react
-
 yarn add @formspree/react
-
-pnpm add @formspree/react
 ```
 
-_Note: `@formspree/core` is a dependency of `@formspree/react`, so you don't need to install it separately._
+### [`@formspree/ajax`](./packages/formspree-ajax)
 
-### `@formspree/ajax`
-
-Vanilla JavaScript library for declarative form handling with plain HTML forms. No framework required — use data attributes and a single `initForm()` call, or load via a script tag with the `window.formspree()` global API.
+Vanilla JavaScript library for declarative form handling. No framework required.
 
 ```sh
-npm install @formspree/ajax
-
 yarn add @formspree/ajax
 ```
 
-_Note: `@formspree/core` is a dependency of `@formspree/ajax`, so you don't need to install it separately._
-
-Or via CDN (no bundler needed):
-
-```html
-<script>
-  window.formspree =
-    window.formspree ||
-    function () {
-      (formspree.q = formspree.q || []).push(arguments);
-    };
-  formspree('initForm', { formElement: '#my-form', formId: 'YOUR_FORM_ID' });
-</script>
-<script src="https://unpkg.com/@formspree/ajax@1" defer></script>
-```
-
-See the [@formspree/ajax README](./packages/formspree-ajax/README.md) for full documentation.
+_`@formspree/core` is included as a dependency of both `@formspree/react` and `@formspree/ajax`, so you don't need to install it separately._
 
 ## Help and Support
 
-For help and support please see [the Formspree React docs](https://help.formspree.io/hc/en-us/articles/360055613373).
+For help and support please see [the Formspree docs](https://help.formspree.io).
 
 ## Contributing
 
 Please follow our [contributing guidelines](./CONTRIBUTING.md).
+
+## License
+
+MIT

--- a/packages/formspree-ajax/README.md
+++ b/packages/formspree-ajax/README.md
@@ -2,35 +2,21 @@
 
 A vanilla JavaScript library for declarative form handling with [Formspree](https://formspree.io/). No framework required — works with plain HTML forms via data attributes or a simple JavaScript API.
 
-## Installation
+## Quick Start
 
-### NPM / Yarn
+### With a bundler
+
+Install with your preferred package manager:
 
 ```sh
 npm install @formspree/ajax
-
+# or
 yarn add @formspree/ajax
+# or
+pnpm add @formspree/ajax
 ```
 
-### Script Tag (CDN)
-
-No bundler needed. Add this snippet before the closing `</body>` tag:
-
-```html
-<script>
-  window.formspree =
-    window.formspree ||
-    function () {
-      (formspree.q = formspree.q || []).push(arguments);
-    };
-  formspree('initForm', { formElement: '#my-form', formId: 'YOUR_FORM_ID' });
-</script>
-<script src="https://unpkg.com/@formspree/ajax@1" defer></script>
-```
-
-## Quick Start
-
-### ESM (with a bundler)
+Initialize your form:
 
 ```js
 import { initForm } from '@formspree/ajax';
@@ -41,7 +27,7 @@ initForm({
 });
 ```
 
-### HTML
+Add the HTML:
 
 ```html
 <div data-fs-success></div>
@@ -54,6 +40,33 @@ initForm({
 
   <button type="submit" data-fs-submit-btn>Send</button>
 </form>
+```
+
+### Without a bundler (CDN)
+
+Add this snippet before the closing `</body>` tag — no install or bundler needed:
+
+```html
+<div data-fs-success></div>
+<div data-fs-error></div>
+
+<form id="contact-form">
+  <label for="email">Email</label>
+  <input type="email" id="email" name="email" data-fs-field />
+  <span data-fs-error="email"></span>
+
+  <button type="submit" data-fs-submit-btn>Send</button>
+</form>
+
+<script>
+  window.formspree =
+    window.formspree ||
+    function () {
+      (formspree.q = formspree.q || []).push(arguments);
+    };
+  formspree('initForm', { formElement: '#contact-form', formId: 'YOUR_FORM_ID' });
+</script>
+<script src="https://unpkg.com/@formspree/ajax@1" defer></script>
 ```
 
 That's it. The library handles submission, validation errors, loading state, and success messages automatically.
@@ -69,6 +82,7 @@ These HTML attributes enable declarative form behavior without additional JavaSc
 | `data-fs-success`           | `<div>`                 | Displays a success message after submission. Empty elements get "Thank you!", elements with content are shown as-is.                             |
 | `data-fs-field`             | `<input>`, `<textarea>` | Marks an input to receive `aria-invalid="true"` on error. The field name is read from the element's `name` attribute.                            |
 | `data-fs-submit-btn`        | `<button>`              | Automatically disabled during submission and re-enabled on completion.                                                                           |
+| `data-fs-active`            | any                     | Added by the library to toggle visibility of error and success elements. Use in CSS selectors to style visible messages (e.g. `[data-fs-success][data-fs-active]`). |
 
 ## Configuration
 
@@ -83,8 +97,10 @@ const handle = initForm({
   formId: 'YOUR_FORM_ID', // Your Formspree form ID
 
   // Optional
+  projectId: 'YOUR_PROJECT_ID', // Route to /p/{projectId}/f/{formId}
   origin: 'https://formspree.io', // API origin (default)
   debug: false, // Enable console logging
+  useDefaultStyles: true, // Inject default CSS (default: true)
 
   // Extra data merged into every submission
   data: {
@@ -101,11 +117,12 @@ const handle = initForm({
   onFailure: (context, error) => {},
 
   // Custom rendering (override defaults)
+  // Render functions receive `null` to clear state before each submission.
   enable: (context) => {},
   disable: (context) => {},
-  renderFieldErrors: (context, error) => {},
-  renderSuccess: (context, message) => {},
-  renderFormError: (context, message) => {},
+  renderFieldErrors: (context, error) => {}, // error: SubmissionError | null
+  renderSuccess: (context, message) => {}, // message: string | null
+  renderFormError: (context, message) => {}, // message: string | null
 });
 
 // Clean up when done
@@ -155,33 +172,61 @@ initForm({
 
 ## Styling
 
-Default styles are injected automatically. You can override them with your own CSS:
+Default styles are injected automatically (disable with `useDefaultStyles: false`). You can override them with your own CSS:
 
 ```css
-/* Error message text */
-[data-fs-error] {
+/* All error and success elements are hidden by default */
+[data-fs-error],
+[data-fs-success] {
+  display: none;
+}
+
+/* Field-level error text */
+[data-fs-error][data-fs-active] {
+  display: block;
   color: #dc3545;
+}
+
+[data-fs-error]:not([data-fs-error=''])[data-fs-active] {
   font-size: 12px;
+  margin-top: 4px;
+}
+
+/* Form-level error banner */
+[data-fs-error=''][data-fs-active] {
+  padding: 12px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  font-size: 14px;
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}
+
+/* Success message banner */
+[data-fs-success][data-fs-active] {
+  display: block;
+  padding: 12px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  font-size: 14px;
+  background: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
 }
 
 /* Invalid field border */
 [data-fs-field][aria-invalid='true'] {
   border-color: #dc3545;
 }
-
-/* Success message banner */
-[data-fs-success][data-fs-active] {
-  background: #d4edda;
-  color: #155724;
-}
-
-/* Form-level error banner */
-[data-fs-error=''][data-fs-active] {
-  background: #f8d7da;
-  color: #721c24;
-}
 ```
 
 ## Help and Support
 
 For help and support please see the [Formspree docs](https://help.formspree.io/).
+
+Part of the [formspree-js](https://github.com/formspree/formspree-js) monorepo. See also [`@formspree/core`](../formspree-core) and [`@formspree/react`](../formspree-react).
+
+## License
+
+MIT

--- a/packages/formspree-core/README.md
+++ b/packages/formspree-core/README.md
@@ -2,6 +2,14 @@
 
 The core client library for [Formspree](https://formspree.io).
 
+## Releasing
+
+Run the following to publish a new version:
+
+```
+npm run release
+```
+
 ## Help and Support
 
 For help and support please see the [Formspree docs](https://help.formspree.io).

--- a/packages/formspree-core/README.md
+++ b/packages/formspree-core/README.md
@@ -2,10 +2,12 @@
 
 The core client library for [Formspree](https://formspree.io).
 
-## Releasing
+## Help and Support
 
-Run the following to publish a new version:
+For help and support please see the [Formspree docs](https://help.formspree.io).
 
-```
-npm run release
-```
+Part of the [formspree-js](https://github.com/formspree/formspree-js) monorepo. See also [`@formspree/react`](../formspree-react) and [`@formspree/ajax`](../formspree-ajax).
+
+## License
+
+MIT

--- a/packages/formspree-react/README.md
+++ b/packages/formspree-react/README.md
@@ -1,7 +1,186 @@
 # Formspree React
 
-The React component library for [Formspree](https://formspree.io).
+React hooks and components for seamless form integration with [Formspree](https://formspree.io).
+
+## Installation
+
+Install with your preferred package manager:
+
+```sh
+npm install @formspree/react
+# or
+yarn add @formspree/react
+# or
+pnpm add @formspree/react
+```
+
+**Peer dependencies:** React 16.8, 17, 18, or 19.
+
+_`@formspree/core` is included as a dependency, so you don't need to install it separately._
+
+## Quick Start
+
+```jsx
+import { useForm, ValidationError } from '@formspree/react';
+
+function ContactForm() {
+  const [state, submit, reset] = useForm('YOUR_FORM_ID');
+
+  if (state.succeeded) {
+    return <p>Thanks for your submission!</p>;
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <label htmlFor="email">Email</label>
+      <input id="email" name="email" type="email" />
+      <ValidationError field="email" errors={state.errors} />
+
+      <label htmlFor="message">Message</label>
+      <textarea id="message" name="message" />
+      <ValidationError field="message" errors={state.errors} />
+
+      <ValidationError errors={state.errors} />
+
+      <button type="submit" disabled={state.submitting}>Send</button>
+    </form>
+  );
+}
+```
+
+## `useForm`
+
+The primary hook for form submissions.
+
+```ts
+const [state, submit, reset] = useForm(formKey, options?);
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `formKey` | `string` | Your Formspree form ID (required). |
+| `options.data` | `ExtraData` | Additional fields merged into every submission. |
+| `options.endpoint` | `string` | Custom API origin (default: `https://formspree.io`). |
+| `options.client` | `Client` | Custom Formspree client instance. |
+
+**Returns a tuple:**
+
+| Index | Name | Type | Description |
+| --- | --- | --- | --- |
+| 0 | `state` | object | Current form state (see below). |
+| 1 | `submit` | function | Submit handler — pass to `onSubmit` or call with data directly. |
+| 2 | `reset` | function | Resets all state back to initial values. |
+
+**State properties:**
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `submitting` | `boolean` | `true` while the submission is in flight. |
+| `succeeded` | `boolean` | `true` if the last submission was successful. |
+| `errors` | `SubmissionError \| null` | Validation errors from Formspree, or `null`. |
+| `result` | `SubmissionSuccess \| null` | Success result with optional `next` redirect URL. |
+
+## `useSubmit`
+
+A lower-level hook that returns only a submit handler without managing state. Use this when you need full control over state management.
+
+```ts
+import { useSubmit } from '@formspree/react';
+
+const submit = useSubmit(formKey, options?);
+
+// With a form event
+const handleSubmit = async (e) => {
+  const result = await submit(e);
+  // result is SubmissionSuccess or SubmissionError
+};
+
+// Or with data directly
+const result = await submit({ email: 'user@example.com' });
+```
+
+**Options:**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `options.client` | `Client` | Custom Formspree client instance. |
+| `options.extraData` | `ExtraData` | Additional fields merged into every submission. |
+| `options.origin` | `string` | Custom API origin (default: `https://formspree.io`). |
+
+## `ValidationError`
+
+Renders validation error messages from a submission.
+
+```jsx
+// Field-level errors
+<ValidationError field="email" errors={state.errors} />
+
+// Form-level errors
+<ValidationError errors={state.errors} />
+
+// With a prefix
+<ValidationError field="email" errors={state.errors} prefix="Email" />
+```
+
+**Props:**
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `errors` | `SubmissionError \| null` | The `errors` value from `useForm` state. |
+| `field` | `string` | Show errors for a specific field. Omit for form-level errors. |
+| `prefix` | `string` | Text prepended before each error message. |
+
+Also accepts any standard `<div>` HTML attributes (e.g. `className`, `style`).
+
+Renders nothing when there are no errors for the given field.
+
+## `FormspreeProvider`
+
+Optional context provider for sharing a Formspree client across your app and enabling Stripe payment integration.
+
+```jsx
+import { FormspreeProvider } from '@formspree/react';
+
+function App() {
+  return (
+    <FormspreeProvider project="YOUR_PROJECT_ID" stripePK="pk_test_...">
+      <ContactForm />
+    </FormspreeProvider>
+  );
+}
+```
+
+**Props:**
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `project` | `string` | Formspree project ID. |
+| `stripePK` | `string` | Stripe publishable key — enables Stripe Elements for payment forms. |
+
+When `stripePK` is provided, the provider wraps children in Stripe's `<Elements>` provider. Use the re-exported `CardElement` component for card inputs.
+
+## Extra Data
+
+Append additional fields to every submission using the `data` option. Values can be static strings, sync functions, or async functions. Return `undefined` to skip a field.
+
+```jsx
+const [state, submit] = useForm('YOUR_FORM_ID', {
+  data: {
+    source: 'contact-page',
+    referrer: () => document.referrer || undefined,
+    sessionId: async () => await fetchSessionId(),
+  },
+});
+```
 
 ## Help and Support
 
-For help and support please see [the Formspree React docs](https://help.formspree.io/hc/en-us/articles/360055613373).
+For help and support please see the [Formspree docs](https://help.formspree.io).
+
+Part of the [formspree-js](https://github.com/formspree/formspree-js) monorepo. See also [`@formspree/core`](../formspree-core) and [`@formspree/ajax`](../formspree-ajax).
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Simplify root README with concise package descriptions, yarn-only install commands, and links to individual package READMEs
- Rewrite `@formspree/ajax` README with clearer bundler vs CDN quick start paths, complete default styles, and missing config options (`projectId`, `useDefaultStyles`)
- Add comprehensive `@formspree/react` README documenting `useForm`, `useSubmit`, `ValidationError`, `FormspreeProvider`, and extra data
- Add monorepo links, license section, and support links to all package READMEs

## Test plan
- [ ] Verify all relative links between package READMEs resolve correctly
- [ ] Confirm code examples match current API signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)